### PR TITLE
Add rubocop linting on pre-commit hook

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,31 @@
+Rails:
+  Enabled: true
+
+# Tests or self-documenting code
+Documentation:
+  Enabled: false
+
+# Commonly used screens these days easily fit more than 80 characters.
+Metrics/LineLength:
+  Max: 120
+
+# Too short methods lead to extraction of single-use methods, which can make
+# the code easier to read (by naming things), but can also clutter the class
+Metrics/MethodLength:
+  Max: 20
+
+# The guiding principle of classes is SRP, SRP can't be accurately measured by LoC
+Metrics/ClassLength:
+  Max: 1500
+
+# Disable arbitrary-ish abstract branch condition size check
+Metrics/AbcSize:
+  Enabled: false
+
+# Better diffs
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+# Better diffs
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma

--- a/Gemfile
+++ b/Gemfile
@@ -1,41 +1,42 @@
 source 'https://rubygems.org'
 
 git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
   "https://github.com/#{repo_name}.git"
 end
 
 gem 'devise'
+gem 'pundit'
 gem 'simple_form'
 gem 'slim-rails'
-gem 'pundit'
 gem 'webpacker', '~> 2.0'
 
-gem 'rails', '~> 5.1.2'
+gem 'jbuilder', '~> 2.5'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.7'
-gem 'jbuilder', '~> 2.5'
+gem 'rails', '~> 5.1.2'
 
 group :development, :test do
   # Load env variables from .env file
   gem 'dotenv-rails'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
 end
 
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'pry'
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'pry'
+  gem 'rubocop'
+  # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
+  gem 'web-console', '>= 3.3.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
+    ast (2.3.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
     builder (3.2.3)
@@ -93,7 +94,11 @@ GEM
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     orm_adapter (0.5.0)
+    parallel (1.12.0)
+    parser (2.4.0.0)
+      ast (~> 2.2)
     pg (0.21.0)
+    powerpack (0.1.1)
     pry (0.11.0)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -127,6 +132,8 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.2)
+      rake
     rake (12.0.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -134,6 +141,14 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rubocop (0.51.0)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     selenium-webdriver (3.4.3)
@@ -167,6 +182,7 @@ GEM
     tilt (2.0.7)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
+    unicode-display_width (1.3.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -199,6 +215,7 @@ DEPENDENCIES
   puma (~> 3.7)
   pundit
   rails (~> 5.1.2)
+  rubocop
   selenium-webdriver
   simple_form
   slim-rails

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ rake db:create
 rake db:migrate
 ```
 
+### Setup Hooks
+
+```shell
+chmod -R a+x ./scripts
+./scripts/dev.local install-hooks
+```
+
 ## Run the app
 
 Run the Rails server

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   helper PostsHelper
   def index
-    @posts = Post.order("created_at").last(3).reverse
+    @posts = Post.order('created_at').last(3).reverse
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,8 @@
 class PostsController < ApplicationController
-  before_action :find_post, only: [:show, :edit, :update, :destroy]
-  before_action :authenticate_user!, except: [:index, :show, :search]
+  before_action :find_post, only: %i[show edit update destroy]
+  before_action :authenticate_user!, except: %i[index show search]
   def index
-    @posts = Post.all.order("created_at DESC")
+    @posts = Post.all.order('created_at DESC')
   end
 
   def show
@@ -43,9 +43,8 @@ class PostsController < ApplicationController
 
   def search
     params.permit(:query)
-    puts params[:query]
     @query = params[:query]
-    @posts = Post.where("title ILIKE ? OR content ILIKE ?", "%#{@query}%", "%#{@query}");
+    @posts = Post.where('title ILIKE ? OR content ILIKE ?', "%#{@query}%", "%#{@query}")
   end
 
   private
@@ -57,5 +56,4 @@ class PostsController < ApplicationController
   def post_params
     params.require(:post).permit(:title, :content)
   end
-
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,5 +1,5 @@
 module PostsHelper
-  def TruncateContent(content)
-    content = truncate(content, length:87)
+  def truncate_content(content)
+    truncate(content, length: 87)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,4 @@
 class Post < ApplicationRecord
   belongs_to :user
-  has_many :comments
+  has_many :comments, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  has_many :posts
-  has_many :comments
+  has_many :posts, dependent: :destroy
+  has_many :comments, dependent: :destroy
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -11,7 +11,7 @@ class ApplicationPolicy
   end
 
   def show?
-    scope.where(:id => record.id).exists?
+    scope.where(id: record.id).exists?
   end
 
   def create?

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,5 +1,5 @@
 class CommentPolicy < ApplicationPolicy
   def owner?
-    user.admin? or record.user_id == user.id
+    user.admin? || (record.user_id == user.id)
   end
 end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -1,5 +1,5 @@
 class PostPolicy < ApplicationPolicy
   def owner?
-    user.admin? or record.user_id == user.id
+    user.admin? || (record.user_id == user.id)
   end
 end

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -12,7 +12,7 @@ section.card.card-2.mx1.mb1
               img.circle.user-icon src="https://i.pinimg.com/564x/7c/c7/a6/7cc7a630624d20f7797cb4c8e93c09c1.jpg"
             div.table-cell.align-middle.pr1
               h5.h5.m0.card-listItem-header=post.title
-              p.m0.card-listItem-text=TruncateContent(post.content)
+              p.m0.card-listItem-text=truncate_content(post.content)
 
   div.right-align.py2.pr2
     a.btn.btn-secondary.mr2 Visit Forum

--- a/bin/setup
+++ b/bin/setup
@@ -21,7 +21,6 @@ chdir APP_ROOT do
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
 
-
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
   #   cp 'config/database.yml.sample', 'config/database.yml'

--- a/bin/spring
+++ b/bin/spring
@@ -8,7 +8,7 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version

--- a/bin/webpack
+++ b/bin/webpack
@@ -1,27 +1,27 @@
 #!/usr/bin/env ruby
 $stdout.sync = true
 
-require "shellwords"
-require "yaml"
+require 'shellwords'
+require 'yaml'
 
-ENV["RAILS_ENV"] ||= "development"
-RAILS_ENV = ENV["RAILS_ENV"]
+ENV['RAILS_ENV'] ||= 'development'
+RAILS_ENV = ENV['RAILS_ENV']
 
-ENV["NODE_ENV"] ||= RAILS_ENV
-NODE_ENV = ENV["NODE_ENV"]
+ENV['NODE_ENV'] ||= RAILS_ENV
+NODE_ENV = ENV['NODE_ENV']
 
-APP_PATH          = File.expand_path("../", __dir__)
-NODE_MODULES_PATH = File.join(APP_PATH, "node_modules")
+APP_PATH          = File.expand_path('../', __dir__)
+NODE_MODULES_PATH = File.join(APP_PATH, 'node_modules')
 WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/#{NODE_ENV}.js")
 
 unless File.exist?(WEBPACK_CONFIG)
-  puts "Webpack configuration not found."
-  puts "Please run bundle exec rails webpacker:install to install webpacker"
+  puts 'Webpack configuration not found.'
+  puts 'Please run bundle exec rails webpacker:install to install webpacker'
   exit!
 end
 
-newenv  = { "NODE_PATH" => NODE_MODULES_PATH.shellescape }
-cmdline = ["yarn", "run", "webpack", "--", "--config", WEBPACK_CONFIG] + ARGV
+newenv  = { 'NODE_PATH' => NODE_MODULES_PATH.shellescape }
+cmdline = ['yarn', 'run', 'webpack', '--', '--config', WEBPACK_CONFIG] + ARGV
 
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -1,19 +1,19 @@
 #!/usr/bin/env ruby
 $stdout.sync = true
 
-require "shellwords"
-require "yaml"
+require 'shellwords'
+require 'yaml'
 
-ENV["RAILS_ENV"] ||= "development"
-RAILS_ENV = ENV["RAILS_ENV"]
+ENV['RAILS_ENV'] ||= 'development'
+RAILS_ENV = ENV['RAILS_ENV']
 
-ENV["NODE_ENV"] ||= RAILS_ENV
-NODE_ENV = ENV["NODE_ENV"]
+ENV['NODE_ENV'] ||= RAILS_ENV
+NODE_ENV = ENV['NODE_ENV']
 
-APP_PATH          = File.expand_path("../", __dir__)
-CONFIG_FILE       = File.join(APP_PATH, "config/webpacker.yml")
-NODE_MODULES_PATH = File.join(APP_PATH, "node_modules")
-WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/development.js")
+APP_PATH          = File.expand_path('../', __dir__)
+CONFIG_FILE       = File.join(APP_PATH, 'config/webpacker.yml')
+NODE_MODULES_PATH = File.join(APP_PATH, 'node_modules')
+WEBPACK_CONFIG    = File.join(APP_PATH, 'config/webpack/development.js')
 
 def args(key)
   index = ARGV.index(key)
@@ -21,22 +21,22 @@ def args(key)
 end
 
 begin
-  dev_server = YAML.load_file(CONFIG_FILE)["development"]["dev_server"]
+  dev_server = YAML.load_file(CONFIG_FILE)['development']['dev_server']
 
-  DEV_SERVER_HOST = "http#{"s" if args('--https') || dev_server["https"]}://#{args('--host') || dev_server["host"]}:#{args('--port') || dev_server["port"]}"
-
+  DEV_SERVER_HOST = "http#{'s' if args('--https') || dev_server['https']}://#{args('--host') ||
+    dev_server['host']}:#{args('--port') || dev_server['port']}".freeze
 rescue Errno::ENOENT, NoMethodError
   puts "Webpack dev_server configuration not found in #{CONFIG_FILE}."
-  puts "Please run bundle exec rails webpacker:install to install webpacker"
+  puts 'Please run bundle exec rails webpacker:install to install webpacker'
   exit!
 end
 
 newenv = {
-  "NODE_PATH" => NODE_MODULES_PATH.shellescape,
-  "ASSET_HOST" => DEV_SERVER_HOST.shellescape
+  'NODE_PATH' => NODE_MODULES_PATH.shellescape,
+  'ASSET_HOST' => DEV_SERVER_HOST.shellescape,
 }.freeze
 
-cmdline = ["yarn", "run", "webpack-dev-server", "--", "--progress", "--color", "--config", WEBPACK_CONFIG] + ARGV
+cmdline = ['yarn', 'run', 'webpack-dev-server', '--', '--progress', '--color', '--config', WEBPACK_CONFIG] + ARGV
 
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline

--- a/bin/yarn
+++ b/bin/yarn
@@ -2,10 +2,10 @@
 VENDOR_PATH = File.expand_path('..', __dir__)
 Dir.chdir(VENDOR_PATH) do
   begin
-    exec "yarnpkg #{ARGV.join(" ")}"
+    exec "yarnpkg #{ARGV.join(' ')}"
   rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn 'Yarn executable was not detected in the system.'
+    warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
     exit 1
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module HelpLesotho
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-    config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
+    config.action_dispatch.rescue_responses['Pundit::NotAuthorizedError'] = :forbidden
 
     # Use webpack for frontend builds
     config.assets.enabled = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,12 +13,12 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
+      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}",
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -80,7 +80,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,8 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '5b89630418af0693c5301fb9805ffe407cdbe9fc00f5e0408ba54961941f31cc85829e2fd1f4e7a48169f567d9ad0cc9c3546222c2c5fb21c7b14897e4412521'
+  # config.secret_key = '5b89630418af0693c5301fb9805ffe407cdbe9fc00f5e0408ba54961941f31cc85829e2fd1f4e7a48169f567d9ad0c'
+  #  + 'c9c3546222c2c5fb21c7b14897e4412521'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -108,7 +109,8 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = '68e76ebae78e8b0ecf2d83a3d16137ced4a39817a51f9b5757a02c67215f3a8170562d946906e369dbae886e7ebc933b26e16f9b18a8772268e6dc6f75d414f0'
+  # config.pepper = '68e76ebae78e8b0ecf2d83a3d16137ced4a39817a51f9b5757a02c67215f3a8170562d946906e369dbae886e7ebc933b26'
+  #  + 'e16f9b18a8772268e6dc6f75d414f0'
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,16 +4,16 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  get '/posts/search', to: 'posts#search';
+  get '/posts/search', to: 'posts#search'
   resources :posts do
     resources :comments
   end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,6 @@
-%w(
+%w[
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+].each { |path| Spring.watch(path) }

--- a/db/migrate/20170708205410_devise_create_users.rb
+++ b/db/migrate/20170708205410_devise_create_users.rb
@@ -2,8 +2,8 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.1]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
       t.string   :reset_password_token
@@ -29,7 +29,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.1]
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
-
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,47 +10,47 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170714233401) do
-
+# rubocop:disable Metrics/BlockLength
+ActiveRecord::Schema.define(version: 20170714233401) do # rubocop:disable Style/NumericLiterals
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "comments", force: :cascade do |t|
-    t.text "comment"
-    t.bigint "post_id"
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["post_id"], name: "index_comments_on_post_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', force: :cascade do |t|
+    t.text 'comment'
+    t.bigint 'post_id'
+    t.bigint 'user_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['post_id'], name: 'index_comments_on_post_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "posts", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "user_id"
+  create_table 'posts', force: :cascade do |t|
+    t.string 'title'
+    t.text 'content'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet "current_sign_in_ip"
-    t.inet "last_sign_in_ip"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "admin", default: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.integer 'sign_in_count', default: 0, null: false
+    t.datetime 'current_sign_in_at'
+    t.datetime 'last_sign_in_at'
+    t.inet 'current_sign_in_ip'
+    t.inet 'last_sign_in_ip'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.boolean 'admin', default: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
 
-  add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
+  add_foreign_key 'comments', 'posts'
+  add_foreign_key 'comments', 'users'
 end

--- a/lib/tasks/webpack-minimize.rake
+++ b/lib/tasks/webpack-minimize.rake
@@ -1,6 +1,6 @@
 namespace :webp do
-  desc "Run webpack with NODE_ENV set to production"
+  desc 'Run webpack with NODE_ENV set to production'
   task :min do
-    sh "NODE_ENV=production bin/webpack"
+    sh 'NODE_ENV=production bin/webpack'
   end
 end

--- a/scripts/dev.local
+++ b/scripts/dev.local
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This script is used to setup, run, and do anything in the development environment
+
+##
+# Links git hooks
+install-hooks() {
+  HOOK_DIR=$(git rev-parse --show-toplevel)/.git/hooks
+  ln -sfn ../scripts/hooks $HOOK_DIR
+}
+
+##
+# Bunch of usage information
+help () {
+
+  # help and usage message
+  echo "Usage: ./dev.local <OPTION>"
+  echo ""
+  echo "Available options"
+  echo "  install-hooks - sets up git hooks"
+  echo ""
+}
+
+main () {
+  if [[ ${1} = "install-hooks" ]]; then
+      install-hooks
+  else
+      help
+  fi
+}
+
+main "$@"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'english'
+require 'rubocop'
+
+ADDED_OR_MODIFIED = /A|AM|^M/
+
+changed_files =
+  `git status --porcelain`
+  .split(/\n/)
+  .select { |file_name_with_status| file_name_with_status =~ ADDED_OR_MODIFIED }
+  .map { |file_name_with_status| file_name_with_status.split(' ')[1] }
+  .select { |file_name| File.extname(file_name) == '.rb' }
+  .join(' ')
+
+puts 'Running pre-commit lint test! Use `git commit --no-verify` to skip'
+system("rubocop #{changed_files}") unless changed_files.empty?
+
+exit $CHILD_STATUS.to_s[-1].to_i

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,15 +1,13 @@
 require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
-
-  test "comment must have a user" do
+  test 'comment must have a user' do
     comment = new_comment(user: nil)
-    assert_not comment.save 
+    assert_not comment.save
   end
 
-  test "comment must belong to a post" do
+  test 'comment must belong to a post' do
     comment = new_comment(post: nil)
-    assert_not comment.save 
+    assert_not comment.save
   end
-
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,10 +1,8 @@
 require 'test_helper'
 
 class PostTest < ActiveSupport::TestCase
-
-  test "post must have a user" do
+  test 'post must have a user' do
     post = new_post(user: nil)
-    assert_not post.save 
+    assert_not post.save
   end
-
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,15 +1,13 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-
-  test "should not save user without email" do
+  test 'should not save user without email' do
     user = new_user(email: nil)
     assert_not user.save
   end
 
-  test "should not save user without password" do
+  test 'should not save user without password' do
     user = new_user(password: nil)
     assert_not user.save
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,49 +1,50 @@
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
-class ActiveSupport::TestCase
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
+class ActiveSupport
+  class TestCase
+    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+    fixtures :all
 
-  # Add more helper methods to be used by all tests here...
- 
-  def new_user(params = {})
-    User.new({ 
-      email: "test@email.com",
-      password: "password",
-    }.merge(params))
+    # Add more helper methods to be used by all tests here...
+
+    def new_user(params = {})
+      User.new({
+        email: 'test@email.com',
+        password: 'password',
+      }.merge(params))
+    end
+
+    def create_user(params = {})
+      return @user if @user
+      @user = new_user(params)
+      @user.save!
+      @user
+    end
+
+    def new_comment(params = {})
+      Comment.new({
+        user: create_user,
+        post: create_post,
+      }.merge(params))
+    end
+
+    def create_comment
+      comment = new_comment
+      comment.save!
+      comment
+    end
+
+    def new_post(params = {})
+      Post.new({
+        user: create_user,
+      }.merge(params))
+    end
+
+    def create_post
+      post = new_post
+      post.save!
+      post
+    end
   end
-
-  def create_user(params = {})
-    return @user if @user
-    @user = new_user
-    @user.save!
-    @user
-  end
-
-  def new_comment(params = {})
-    Comment.new({ 
-      user: create_user,
-      post: create_post,
-    }.merge(params))
-  end
-
-  def create_comment
-    comment = new_comment
-    comment.save!
-    comment
-  end
-
-  def new_post(params = {})
-    Post.new({ 
-      user: create_user,
-    }.merge(params))
-  end
-
-  def create_post
-    post = new_post
-    post.save!
-    post
-  end
-
 end


### PR DESCRIPTION
As we write more Ruby, we should add some linting to ensure code styling consistencies. See [README.md](https://github.com/uwblueprint/help-lesotho/blob/d13b1844b0b25dd7fc5fa8f7e8fb7f50ff92afca/README.md#setup-hooks) for setup—this will make `rubocop` run on every `git commit` for staged files. 

We should do the same with eslint for Javascript.

Reviewing by individual commits may be easier. Pre-commit file from https://gist.github.com/mpeteuil/6147292

cc @mmqw @ajyang99 @howardyu97 