### PR TITLE
Don't rubocop schema and node_modules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+AllCops:
+  Exclude:
+    - 'db/schema.rb' # Auto-generated
+    - 'node_modules/**/*' # External
+
 Rails:
   Enabled: true
 

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -14,6 +14,6 @@ changed_files =
   .join(' ')
 
 puts 'Running pre-commit lint test! Use `git commit --no-verify` to skip'
-system("rubocop #{changed_files}") unless changed_files.empty?
+system("rubocop --force-exclusion #{changed_files}") unless changed_files.empty?
 
 exit $CHILD_STATUS.to_s[-1].to_i


### PR DESCRIPTION
If you dump a schema, it doesn't like to satisfy rubocop.